### PR TITLE
Fix running on Ruby 2.0

### DIFF
--- a/lib/pippi/checks/assert_with_nil.rb
+++ b/lib/pippi/checks/assert_with_nil.rb
@@ -19,8 +19,8 @@ module Pippi::Checks
           def self._pippi_check_assert_with_nil
             ancestors.find { |x| x == ActiveSupport::TestCase }._pippi_other_check_assert_with_nil
           end
+          prepend Pippi::Checks::AssertWithNil::MyAssertEqual
         end
-        ActiveSupport::TestCase.prepend Pippi::Checks::AssertWithNil::MyAssertEqual
       end
     end
 

--- a/lib/pippi/checks/map_followed_by_flatten.rb
+++ b/lib/pippi/checks/map_followed_by_flatten.rb
@@ -35,8 +35,8 @@ module Pippi::Checks
         class << self
           attr_reader :_pippi_check_map_followed_by_flatten
         end
+        prepend MyMap
       end
-      Array.prepend MyMap
     end
 
     class Documentation

--- a/lib/pippi/checks/reverse_followed_by_each.rb
+++ b/lib/pippi/checks/reverse_followed_by_each.rb
@@ -13,7 +13,7 @@ module Pippi::Checks
         if self.class._pippi_check_reverse_followed_by_each.nil?
           # Ignore Array subclasses since reverse or each may have difference meanings
         else
-          result.singleton_class.prepend MyEach
+          result.singleton_class.class_eval { prepend MyEach }
           self.class._pippi_check_reverse_followed_by_each.array_mutator_methods.each do |this_means_its_ok_sym|
             result.define_singleton_method(this_means_its_ok_sym, self.class._pippi_check_reverse_followed_by_each.its_ok_watcher_proc(MyEach, :each))
           end
@@ -29,8 +29,8 @@ module Pippi::Checks
         class << self
           attr_reader :_pippi_check_reverse_followed_by_each
         end
+        prepend MyReverse
       end
-      Array.prepend MyReverse
     end
 
     class Documentation

--- a/lib/pippi/checks/select_followed_by_empty.rb
+++ b/lib/pippi/checks/select_followed_by_empty.rb
@@ -34,8 +34,8 @@ module Pippi::Checks
         def self._pippi_check_select_followed_by_empty
           @_pippi_check_select_followed_by_empty
         end
+        prepend MySelect
       end
-      Array.prepend MySelect
     end
 
     class Documentation

--- a/lib/pippi/checks/select_followed_by_first.rb
+++ b/lib/pippi/checks/select_followed_by_first.rb
@@ -34,8 +34,8 @@ module Pippi::Checks
         class << self
           attr_reader :_pippi_check_select_followed_by_first
         end
+        prepend MySelect
       end
-      Array.prepend MySelect
     end
 
     class Documentation

--- a/lib/pippi/checks/select_followed_by_select.rb
+++ b/lib/pippi/checks/select_followed_by_select.rb
@@ -28,8 +28,8 @@ module Pippi::Checks
         def self._pippi_check_select_followed_by_select
           @_pippi_check_select_followed_by_select
         end
+        prepend MyFirstSelect
       end
-      Array.prepend MyFirstSelect
     end
 
     class Documentation

--- a/lib/pippi/checks/select_followed_by_size.rb
+++ b/lib/pippi/checks/select_followed_by_size.rb
@@ -31,8 +31,8 @@ module Pippi::Checks
         class << self
           attr_reader :_pippi_check_select_followed_by_size
         end
+        prepend MySelect
       end
-      Array.prepend MySelect
     end
 
     class Documentation


### PR DESCRIPTION
Module#prepend was made public in Ruby 2.1.
