### PR TITLE
Update RSpec instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here's a [demo Rails application](https://github.com/tcopeland/pippi_demo#pippi-
 ### Rails with rspec
 
 * Add `gem 'pippi'` to the `test` group in your project's `Gemfile`
-* Add this to the top of `spec/spec_helper.rb`:
+* Add this to `spec/spec_helper.rb`, just below the `require 'rspec/rails'` line (if there is one):
 
 ```ruby
 if ENV['USE_PIPPI'].present?


### PR DESCRIPTION
The `present?` method is Rails-provided, so adding the pippi auto-runner code at the very top of a Rails `spec_helper.rb` file gives you an error:

```
... spec/spec_helper.rb:1:in '<top (required)>': undefined method `present?' for "true":String (NoMethodError)
```

Adding the code snippet below the `require 'rspec/rails` line does the trick :smile: 
