### PR TITLE
Changes to output format

### DIFF
--- a/lib/pippi/problem.rb
+++ b/lib/pippi/problem.rb
@@ -10,7 +10,7 @@ module Pippi
 
     # TODO probably need various reporting formats
     def to_text
-      "#{file_path},#{check_class.name.split('::').last},#{line_number}"
+      "#{file_path}:#{line_number},#{demodulized_check_class_name}"
     end
 
     # TODO correct method?
@@ -21,7 +21,13 @@ module Pippi
     end
 
     def to_s
-      "#{file_path},#{check_class.name.split('::').last},#{line_number}"
+      "#{file_path}:#{line_number},#{demodulized_check_class_name}"
     end
+
+  private
+    def demodulized_check_class_name
+      check_class.name.split('::').last
+    end
+
   end
 end

--- a/test/unit/problem_test.rb
+++ b/test/unit/problem_test.rb
@@ -18,4 +18,9 @@ class ProblemTest < MiniTest::Test
     p4 = Pippi::Problem.new(file_path: 'foo', line_number: 42, check_class: 'Array')
     assert !p1.eql?(p4)
   end
+
+  def test_to_text_has_expected_format
+    p = Pippi::Problem.new(file_path: 'foo/bar.rb', line_number: 42, check_class: String)
+    assert_equal p.to_text, 'foo/bar.rb:42,String'
+  end
 end


### PR DESCRIPTION
Hey Tom, 

I played a bit around with Pippi yesterday. Seems to be a very usefull tool. I really liked it. Thank you.

But I think the output format is suboptimal: Some text editors (Sublime Text for example) support to open files and jump directly to a specified line when you enter the file name and the line separated with a semicolon. 

Changing the output format from

```
opt/rubies/2.1.5/lib/ruby/2.1.0/forwardable.rb,SelectFollowedByFirst,183
```

to

```
opt/rubies/2.1.5/lib/ruby/2.1.0/forwardable.rb:183,SelectFollowedByFirst
```

allowed me to just copy'n'paste the path with the line number into Sublime Text and saved me some time.

I know this PR this is a very opinionated. What do you think?

Cheers
Martin