### PR TITLE
Fix NameError: uninitialized constant Pippi::Report::Set

### DIFF
--- a/lib/pippi/report.rb
+++ b/lib/pippi/report.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Pippi
   class Report
     attr_reader :problems, :removed


### PR DESCRIPTION
Hello. First of all great idea and gem! 

I've spotted an issue when trying to run a simple ruby script like:
```ruby
require 'pippi'
Pippi::AutoRunner.new(checkset: 'basic')
[1, 2, 3].select { |x| x > 1 }.first
```
That fails with something along ```NameError: uninitialized constant Pippi::Report::Set```. 
